### PR TITLE
target is an input not an env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ jobs:
       uses: actions/checkout@master
     - name: lint
       uses: luke142367/Docker-Lint-Action@v1.0.0
+      with:
+        target: Dockerfile
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TARGET: Dockerfile
 ```
 ## Annotations
 
@@ -31,4 +32,4 @@ This is a list of the arguments this action can take:
 | Name         | Required | Description                                                        |
 |--------------|----------|--------------------------------------------------------------------|
 | GITHUB_TOKEN | Yes      | This can simply be set to `${{secrets.GITHUB_TOKEN}}`              |
-| TARGET       | No       | This is a space separated list of targets to run Dockerfilelint on. By default this is set to 'Dockerfile' |
+| target       | No       | This is a space separated list of targets to run Dockerfilelint on. By default this is set to 'Dockerfile' |


### PR DESCRIPTION
`target` is an input which need to be defined via `with`, this will be
translated to `INPUT_TARGET` as you read it from
https://github.com/luke142367/Docker-Lint-Action/blob/master/src/main.ts#L7

I propose with this PR to update documentation.

Example for me, testing multiple Dockerfiles:

```
[...]
    - name: lint
      uses: luke142367/Docker-Lint-Action@v1.0.1
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      with:
        target: Dockerfile 0.4.9/Dockerfile 0.5.1/Dockerfile
```

Source: https://help.github.com/en/actions/building-actions/metadata-syntax-for-github-actions#inputs